### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 MBImageConstants
 ================
 
-MBImageConstants is a simple XCode 5 precompile script that generates precompiler defines 
+MBImageConstants is a simple Xcode 5 precompile script that generates precompiler defines 
 corresponding to image sets found in a project's assets. 
 It allows autocompletion for image names and protects against typos.
 
 Requirements
 ------------
-Script works with XCode 5 and project using Images.xcassets to store images. It is a Ruby script so it needs Ruby installed on the build machine.
+Script works with Xcode 5 and project using Images.xcassets to store images. It is a Ruby script so it needs Ruby installed on the build machine.
 
 Installation
 ------------


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
